### PR TITLE
Refactor: Use frformats package 

### DIFF
--- a/csv_detective/detect_fields/FR/geo/latitude_l93/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/latitude_l93/__init__.py
@@ -12,7 +12,7 @@ def _is(val):
             return LatitudeL93.is_valid(val)
 
         elif type(val) is str and is_float(val):
-                return LatitudeL93.is_valid(float_casting(val))
+            return LatitudeL93.is_valid(float_casting(val))
 
         return False
 

--- a/csv_detective/detect_fields/FR/geo/latitude_l93/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/latitude_l93/__init__.py
@@ -1,12 +1,22 @@
+from frformat import LatitudeL93
 from csv_detective.detect_fields.other.float import _is as is_float
+from csv_detective.detect_fields.other.float import float_casting
+
 
 PROPORTION = 0.9
 
 
 def _is(val):
-    '''Renvoie True si val peut etre une latitude en Lambert 93'''
     try:
-        is_float(val) and float(val) >= 6037008 and float(val) <= 7230728
+        if type(val) is float or type(val) is int:
+            return LatitudeL93.is_valid(val)
+
+        elif type(val) is str:
+            if is_float(val):
+                return LatitudeL93.is_valid(float_casting(val))
+
+        return False
+
     except ValueError:
         return False
     except OverflowError:

--- a/csv_detective/detect_fields/FR/geo/latitude_l93/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/latitude_l93/__init__.py
@@ -11,8 +11,7 @@ def _is(val):
         if type(val) is float or type(val) is int:
             return LatitudeL93.is_valid(val)
 
-        elif type(val) is str:
-            if is_float(val):
+        elif type(val) is str and is_float(val):
                 return LatitudeL93.is_valid(float_casting(val))
 
         return False

--- a/csv_detective/detect_fields/FR/geo/latitude_l93/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/latitude_l93/__init__.py
@@ -16,7 +16,5 @@ def _is(val):
 
         return False
 
-    except ValueError:
-        return False
-    except OverflowError:
+    except (ValueError, OverflowError):
         return False

--- a/csv_detective/detect_fields/FR/geo/longitude_l93/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/longitude_l93/__init__.py
@@ -11,9 +11,8 @@ def _is(val):
         if type(val) is float or type(val) is int:
             return LongitudeL93.is_valid(val)
 
-        elif type(val) is str:
-            if is_float(val):
-                return LongitudeL93.is_valid(float_casting(val))
+        elif type(val) is str and is_float(val):
+            return LongitudeL93.is_valid(float_casting(val))
 
         return False
 

--- a/csv_detective/detect_fields/FR/geo/longitude_l93/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/longitude_l93/__init__.py
@@ -16,8 +16,5 @@ def _is(val):
 
         return False
 
-    except ValueError:
+    except (ValueError, OverflowError):
         return False
-    except OverflowError:
-        return False
-

--- a/csv_detective/detect_fields/FR/geo/longitude_l93/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/longitude_l93/__init__.py
@@ -1,13 +1,24 @@
+from frformat import LongitudeL93
 from csv_detective.detect_fields.other.float import _is as is_float
+from csv_detective.detect_fields.other.float import float_casting
+
 
 PROPORTION = 0.9
 
 
 def _is(val):
-    '''Renvoie True si val peut etre une longitude en métropole'''
     try:
-        is_float(val) and float(val) >= -357823 and float(val) <= 1313633
+        if type(val) is float or type(val) is int:
+            return LongitudeL93.is_valid(val)
+
+        elif type(val) is str:
+            if is_float(val):
+                return LongitudeL93.is_valid(float_casting(val))
+
+        return False
+
     except ValueError:
         return False
     except OverflowError:
         return False
+

--- a/csv_detective/detect_fields/FR/other/code_rna/__init__.py
+++ b/csv_detective/detect_fields/FR/other/code_rna/__init__.py
@@ -1,8 +1,5 @@
-import re
+from frformat import CodeRNA
 
 PROPORTION = 0.9
 
-
-def _is(val):
-    '''Repere le code RNA'''
-    return bool(re.match(r'^[wW]\d{9}$', val))
+_is = CodeRNA.is_valid

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ odfpy==1.4.1
 requests==2.31.0
 responses==0.25.0
 python-magic==0.4.27
-frformat==0.2.2
+frformat==0.3.0

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -11,6 +11,7 @@ from csv_detective.detect_fields.FR.geo import (
     commune,
     departement,
     insee_canton,
+    latitude_l93,
     pays,
     region,
 )
@@ -199,9 +200,10 @@ def test_do_not_match_code_departement():
     val = "00"
     assert not code_departement._is(val)
 
+
 # code_fantoir
 def test_match_code_fantoir():
-    vals = ["7755A", "B150B", "ZA04C","ZB03D"]
+    vals = ["7755A", "B150B", "ZA04C", "ZB03D"]
     for val in vals:
         assert code_fantoir._is(val)
 
@@ -210,6 +212,7 @@ def test_do_not_match_code_fantoir():
     vals = ["7755", "ZA99A"]
     for val in vals:
         assert not code_fantoir._is(val)
+
 
 # code_region
 def test_match_code_region():
@@ -220,6 +223,7 @@ def test_match_code_region():
 def test_do_not_match_code_region():
     val = "55"
     assert not code_region._is(val)
+
 
 # commune
 def test_match_commune():
@@ -242,6 +246,7 @@ def test_do_not_match_departement():
     val = "new york"
     assert not departement._is(val)
 
+
 # insee_canton
 def test_match_canton():
     val = "nantua"
@@ -251,6 +256,20 @@ def test_match_canton():
 def test_do_not_match_canton():
     val = "new york"
     assert not departement._is(val)
+
+
+# latitude_l93
+def test_match_latitude_l93():
+    vals = [6037008, 7123528.5, "7124528,5"]
+    for val in vals:
+        assert latitude_l93._is(val)
+
+
+def test_do_not_match_latitude_93():
+    vals = [0, -6734529.6, 7245669.8, "3422674,78", "32_34"]
+    for val in vals:
+        assert not latitude_l93._is(val)
+
 
 # pays
 def test_match_pays():

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -419,8 +419,9 @@ def test_match_rna():
 
 
 def test_do_not_match_rna():
-    val = "W111111111111111111111111111111111111"
-    assert not code_rna._is(val)
+    vals = ["W111111111111111111111111111111111111", "w143788974", "W12", "678W23456", "165789325", "Wa1#89sf&h"]
+    for val in vals:
+        assert not code_rna._is(val)
 
 
 def test_match_waldec():

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -12,6 +12,7 @@ from csv_detective.detect_fields.FR.geo import (
     departement,
     insee_canton,
     latitude_l93,
+    longitude_l93,
     pays,
     region,
 )
@@ -269,6 +270,19 @@ def test_do_not_match_latitude_93():
     vals = [0, -6734529.6, 7245669.8, "3422674,78", "32_34"]
     for val in vals:
         assert not latitude_l93._is(val)
+
+
+# longitude_l93
+def test_match_longitude_l93():
+    vals = [0, -154, "1265783,45", 34723.4]
+    for val in vals:
+        assert longitude_l93._is(val)
+
+
+def test_do_not_match_longitude_93():
+    vals = [1456669.8, "-776225", "346_3214"]
+    for val in vals:
+        assert not longitude_l93._is(val)
 
 
 # pays


### PR DESCRIPTION
# Context

The library fr-format has been developed for sharing validation functions between [validata](https://gitlab.com/validata-table) and csv-detective, and to introduce a standard library to validate typical French formats. 

The aim of this PR is to replace custom validation with the implementation of fr-format and it's a follow-up to the previous [PR](https://github.com/datagouv/csv-detective/pull/83)

# Refactorings

- Latitude_l93
- Longitude_l93
- code RNA

# Change in behavior 

CodeRNA does not allow 'w' as first letter, only uppercase 'W'.