### PR TITLE
Refactor: Use Options class instead of strict parameter

### DIFF
--- a/csv_detective/detect_fields/FR/geo/code_commune_insee/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/code_commune_insee/__init__.py
@@ -1,8 +1,8 @@
-from frformat import CodeCommuneInsee, Options
+from frformat import CodeCommuneInsee
 
 PROPORTION = 0.75
 
-_code_commune_insee = CodeCommuneInsee(Options())
+_code_commune_insee = CodeCommuneInsee()
 
 
 def _is(val):

--- a/csv_detective/detect_fields/FR/geo/code_commune_insee/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/code_commune_insee/__init__.py
@@ -1,5 +1,9 @@
-from frformat import CodeCommuneInsee
+from frformat import CodeCommuneInsee, Options
 
 PROPORTION = 0.75
 
-_is = CodeCommuneInsee.is_valid
+_code_commune_insee = CodeCommuneInsee(Options())
+
+
+def _is(val):
+    return _code_commune_insee.is_valid(val)

--- a/csv_detective/detect_fields/FR/geo/code_departement/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/code_departement/__init__.py
@@ -1,8 +1,13 @@
-from frformat import NumeroDepartement
+from frformat import NumeroDepartement, Options
 
 PROPORTION = 1
 
 
 def _is(val):
-
-    return NumeroDepartement.is_valid(val, strict = False) 
+    options = Options(
+        ignore_case=True,
+        ignore_non_alphanumeric=True,
+        ignore_extra_white_space=True,
+        ignore_accents=True
+        )
+    return NumeroDepartement.is_valid(val, options)

--- a/csv_detective/detect_fields/FR/geo/code_departement/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/code_departement/__init__.py
@@ -2,12 +2,15 @@ from frformat import NumeroDepartement, Options
 
 PROPORTION = 1
 
+_options = Options(
+    ignore_case=True,
+    ignore_accents=True,
+    replace_non_alphanumeric_with_space=True,
+    ignore_extra_whitespace=True
+)
+_numero_departement = NumeroDepartement(_options)
+
 
 def _is(val):
-    options = Options(
-        ignore_case=True,
-        ignore_non_alphanumeric=True,
-        ignore_extra_white_space=True,
-        ignore_accents=True
-        )
-    return NumeroDepartement.is_valid(val, options)
+
+    return _numero_departement.is_valid(val)

--- a/csv_detective/detect_fields/FR/geo/code_fantoir/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/code_fantoir/__init__.py
@@ -1,8 +1,8 @@
-from frformat import CodeFantoir, Options
+from frformat import CodeFantoir
 
 PROPORTION = 1
 
-_code_fantoir = CodeFantoir(Options())
+_code_fantoir = CodeFantoir()
 
 
 def _is(val):

--- a/csv_detective/detect_fields/FR/geo/code_fantoir/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/code_fantoir/__init__.py
@@ -2,9 +2,9 @@ from frformat import CodeFantoir, Options
 
 PROPORTION = 1
 
-_code_fontoir = CodeFantoir(Options())
+_code_fantoir = CodeFantoir(Options())
 
 
 def _is(val):
 
-    return _code_fontoir.is_valid(val)
+    return _code_fantoir.is_valid(val)

--- a/csv_detective/detect_fields/FR/geo/code_fantoir/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/code_fantoir/__init__.py
@@ -1,7 +1,10 @@
-from frformat import CodeFantoir
+from frformat import CodeFantoir, Options
 
 PROPORTION = 1
 
-def _is (val):
+_code_fontoir = CodeFantoir(Options())
 
-    return CodeFantoir.is_valid(val)
+
+def _is(val):
+
+    return _code_fontoir.is_valid(val)

--- a/csv_detective/detect_fields/FR/geo/code_postal/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/code_postal/__init__.py
@@ -1,8 +1,8 @@
-from frformat import CodePostal, Options
+from frformat import CodePostal
 
 PROPORTION = 0.9
 
-_code_postal = CodePostal(Options())
+_code_postal = CodePostal()
 
 
 def _is(val):

--- a/csv_detective/detect_fields/FR/geo/code_postal/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/code_postal/__init__.py
@@ -1,5 +1,10 @@
-from frformat import CodePostal
+from frformat import CodePostal, Options
 
 PROPORTION = 0.9
 
-_is = CodePostal.is_valid
+_code_postal = CodePostal(Options())
+
+
+def _is(val):
+
+    return _code_postal.is_valid(val)

--- a/csv_detective/detect_fields/FR/geo/code_region/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/code_region/__init__.py
@@ -1,8 +1,10 @@
-from frformat import CodeRegion
+from frformat import CodeRegion, Options
 
 PROPORTION = 1
+
+_code_region = CodeRegion(Options())
 
 
 def _is(val):
     '''Renvoie True si val peut être un code_région, False sinon'''
-    return CodeRegion.is_valid(val)
+    return _code_region.is_valid(val)

--- a/csv_detective/detect_fields/FR/geo/code_region/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/code_region/__init__.py
@@ -1,8 +1,8 @@
-from frformat import CodeRegion, Options
+from frformat import CodeRegion
 
 PROPORTION = 1
 
-_code_region = CodeRegion(Options())
+_code_region = CodeRegion()
 
 
 def _is(val):

--- a/csv_detective/detect_fields/FR/geo/commune/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/commune/__init__.py
@@ -2,12 +2,16 @@ from frformat import Commune, Options
 
 PROPORTION = 0.9
 
+_options = Options(
+    ignore_case=True,
+    ignore_accents=True,
+    replace_non_alphanumeric_with_space=True,
+    ignore_extra_whitespace=True
+)
+_commune = Commune(_options)
+
+
 def _is(val):
     '''Match avec le nom des communes'''
-    options = Options(
-        ignore_case=True,
-        ignore_non_alphanumeric=True,
-        ignore_extra_white_space=True,
-        ignore_accents=True
-    )
-    return Commune.is_valid(val, options)
+
+    return _commune.is_valid(val)

--- a/csv_detective/detect_fields/FR/geo/commune/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/commune/__init__.py
@@ -1,7 +1,13 @@
-from frformat import Commune
+from frformat import Commune, Options
 
 PROPORTION = 0.9
 
 def _is(val):
-    '''Match avec le nom des communes''' 
-    return Commune.is_valid(val, strict=False)
+    '''Match avec le nom des communes'''
+    options = Options(
+        ignore_case=True,
+        ignore_non_alphanumeric=True,
+        ignore_extra_white_space=True,
+        ignore_accents=True
+    )
+    return Commune.is_valid(val, options)

--- a/csv_detective/detect_fields/FR/geo/departement/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/departement/__init__.py
@@ -1,7 +1,13 @@
-from frformat import Departement
+from frformat import Departement, Options
 
 PROPORTION = 0.9
 
 def _is(val):
     '''Match avec le nom des departements'''
-    return Departement.is_valid(val, strict = False)
+    options = Options(
+        ignore_case=True,
+        ignore_non_alphanumeric=True,
+        ignore_extra_white_space=True,
+        ignore_accents=True
+    )
+    return Departement.is_valid(val, options)

--- a/csv_detective/detect_fields/FR/geo/departement/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/departement/__init__.py
@@ -2,12 +2,16 @@ from frformat import Departement, Options
 
 PROPORTION = 0.9
 
+_options = Options(
+    ignore_case=True,
+    ignore_accents=True,
+    replace_non_alphanumeric_with_space=True,
+    ignore_extra_whitespace=True
+)
+_departement = Departement(_options)
+
+
 def _is(val):
     '''Match avec le nom des departements'''
-    options = Options(
-        ignore_case=True,
-        ignore_non_alphanumeric=True,
-        ignore_extra_white_space=True,
-        ignore_accents=True
-    )
-    return Departement.is_valid(val, options)
+
+    return _departement.is_valid(val)

--- a/csv_detective/detect_fields/FR/geo/insee_canton/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/insee_canton/__init__.py
@@ -1,8 +1,13 @@
-from frformat import Canton
+from frformat import Canton, Options
 
 PROPORTION = 0.9
 
 def _is(val):
     '''Match avec le nom des cantons'''
-
-    return Canton.is_valid(val, strict= False)
+    options = Options(
+        ignore_case=True,
+        ignore_non_alphanumeric=True,
+        ignore_extra_white_space=True,
+        ignore_accents=True
+    )
+    return Canton.is_valid(val, options)

--- a/csv_detective/detect_fields/FR/geo/insee_canton/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/insee_canton/__init__.py
@@ -1,13 +1,16 @@
 from frformat import Canton, Options
 
 PROPORTION = 0.9
+_options = Options(
+    ignore_case=True,
+    ignore_accents=True,
+    replace_non_alphanumeric_with_space=True,
+    ignore_extra_whitespace=True
+)
+_canton = Canton(_options)
+
 
 def _is(val):
     '''Match avec le nom des cantons'''
-    options = Options(
-        ignore_case=True,
-        ignore_non_alphanumeric=True,
-        ignore_extra_white_space=True,
-        ignore_accents=True
-    )
-    return Canton.is_valid(val, options)
+
+    return _canton.is_valid(val)

--- a/csv_detective/detect_fields/FR/geo/latitude_l93/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/latitude_l93/__init__.py
@@ -1,11 +1,11 @@
-from frformat import LatitudeL93, Options
+from frformat import LatitudeL93
 from csv_detective.detect_fields.other.float import _is as is_float
 from csv_detective.detect_fields.other.float import float_casting
 
 
 PROPORTION = 0.9
 
-_latitudel93 = LatitudeL93(Options())
+_latitudel93 = LatitudeL93()
 
 
 def _is(val):

--- a/csv_detective/detect_fields/FR/geo/latitude_l93/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/latitude_l93/__init__.py
@@ -1,18 +1,20 @@
-from frformat import LatitudeL93
+from frformat import LatitudeL93, Options
 from csv_detective.detect_fields.other.float import _is as is_float
 from csv_detective.detect_fields.other.float import float_casting
 
 
 PROPORTION = 0.9
 
+_latitudel93 = LatitudeL93(Options())
+
 
 def _is(val):
     try:
         if isinstance(val, (float, int)):
-            return LatitudeL93.is_valid(val)
+            return _latitudel93.is_valid(val)
 
         elif isinstance(val, str) and is_float(val):
-            return LatitudeL93.is_valid(float_casting(val))
+            return _latitudel93.is_valid(float_casting(val))
 
         return False
 

--- a/csv_detective/detect_fields/FR/geo/longitude_l93/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/longitude_l93/__init__.py
@@ -1,11 +1,11 @@
-from frformat import LongitudeL93, Options
+from frformat import LongitudeL93
 from csv_detective.detect_fields.other.float import _is as is_float
 from csv_detective.detect_fields.other.float import float_casting
 
 
 PROPORTION = 0.9
 
-_longitudel93 = LongitudeL93(Options())
+_longitudel93 = LongitudeL93()
 
 
 def _is(val):

--- a/csv_detective/detect_fields/FR/geo/longitude_l93/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/longitude_l93/__init__.py
@@ -1,18 +1,20 @@
-from frformat import LongitudeL93
+from frformat import LongitudeL93, Options
 from csv_detective.detect_fields.other.float import _is as is_float
 from csv_detective.detect_fields.other.float import float_casting
 
 
 PROPORTION = 0.9
 
+_longitudel93 = LongitudeL93(Options())
+
 
 def _is(val):
     try:
         if isinstance(val, (float, int)):
-            return LongitudeL93.is_valid(val)
+            return _longitudel93.is_valid(val)
 
         elif isinstance(val, str) and is_float(val):
-            return LongitudeL93.is_valid(float_casting(val))
+            return _longitudel93.is_valid(float_casting(val))
 
         return False
 

--- a/csv_detective/detect_fields/FR/geo/pays/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/pays/__init__.py
@@ -1,7 +1,13 @@
-from frformat import Pays
+from frformat import Pays, Options
 
 PROPORTION = 0.6
 
 def _is(val):
     '''Match avec le nom des pays'''
-    return Pays.is_valid(val, strict = False)
+    options = Options(
+        ignore_case=True,
+        ignore_non_alphanumeric=True,
+        ignore_extra_white_space=True,
+        ignore_accents=True
+    )
+    return Pays.is_valid(val, options)

--- a/csv_detective/detect_fields/FR/geo/pays/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/pays/__init__.py
@@ -2,12 +2,15 @@ from frformat import Pays, Options
 
 PROPORTION = 0.6
 
+_options = Options(
+        ignore_case=True,
+        ignore_accents=True,
+        replace_non_alphanumeric_with_space=True,
+        ignore_extra_whitespace=True
+    )
+_pays = Pays(_options)
+
+
 def _is(val):
     '''Match avec le nom des pays'''
-    options = Options(
-        ignore_case=True,
-        ignore_non_alphanumeric=True,
-        ignore_extra_white_space=True,
-        ignore_accents=True
-    )
-    return Pays.is_valid(val, options)
+    return _pays.is_valid(val)

--- a/csv_detective/detect_fields/FR/geo/region/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/region/__init__.py
@@ -2,7 +2,7 @@ from frformat import Region, Options
 
 PROPORTION = 1
  
-_lenient_region_set = {
+_extra_valid_values_set = {
         "alsace",
         "aquitaine",
         "ara",
@@ -57,7 +57,7 @@ _options = Options(
     ignore_accents=True,
     replace_non_alphanumeric_with_space=True,
     ignore_extra_whitespace=True,
-    extra_valid_values=_lenient_region_set
+    extra_valid_values=_extra_valid_values_set
 )
 _region = Region(_options)
 

--- a/csv_detective/detect_fields/FR/geo/region/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/region/__init__.py
@@ -1,11 +1,8 @@
 from frformat import Region, Options
 
 PROPORTION = 1
-
-
-def _is(val):
-    '''Match avec le nom des regions'''
-    lenient_region_set = {
+ 
+_lenient_region_set = {
         "alsace",
         "aquitaine",
         "ara",
@@ -54,11 +51,17 @@ def _is(val):
         "rhone alpes",
         }
 
-    options = Options(
-        ignore_case=True,
-        ignore_non_alphanumeric=True,
-        ignore_extra_white_space=True,
-        ignore_accents=True,
-        extra_valid_values=lenient_region_set
-    )
-    return Region.is_valid(val, options)
+
+_options = Options(
+    ignore_case=True,
+    ignore_accents=True,
+    replace_non_alphanumeric_with_space=True,
+    ignore_extra_whitespace=True,
+    extra_valid_values=_lenient_region_set
+)
+_region = Region(_options)
+
+
+def _is(val):
+    '''Match avec le nom des regions'''
+    return _region.is_valid(val)

--- a/csv_detective/detect_fields/FR/geo/region/__init__.py
+++ b/csv_detective/detect_fields/FR/geo/region/__init__.py
@@ -1,7 +1,64 @@
-from frformat import Region
+from frformat import Region, Options
 
 PROPORTION = 1
 
+
 def _is(val):
     '''Match avec le nom des regions'''
-    return Region.is_valid(val, strict = False)
+    lenient_region_set = {
+        "alsace",
+        "aquitaine",
+        "ara",
+        "aura",
+        "auvergne",
+        "auvergne et rhone alpes",
+        "auvergne rhone alpes",
+        "basse normandie",
+        "bfc",
+        "bourgogne",
+        "bourgogne et franche comte",
+        "bourgogne franche comte",
+        "bretagne",
+        "centre",
+        "centre val de loire",
+        "champagne ardenne",
+        "corse",
+        "franche comte",
+        "ge",
+        "nouvelle aquitaine",
+        "grand est",
+        "guadeloupe",
+        "guyane",
+        "haute normandie",
+        "hauts de france",
+        "hdf",
+        "ile de france",
+        "languedoc roussillon",
+        "la reunion",
+        "la reunion",
+        "limousin",
+        "lorraine",
+        "martinique",
+        "mayotte",
+        "midi pyrenees",
+        "nord pas de calais",
+        "normandie",
+        "npdc",
+        "occitanie",
+        "paca",
+        "pays de la loire",
+        "picardie",
+        "poitou charentes",
+        "provence alpes cote d azur",
+        "reunion",
+        "rhone alpes",
+        }
+
+    options = Options(
+        ignore_case=True,
+        ignore_non_alphanumeric=True,
+        ignore_extra_white_space=True,
+        ignore_accents=True,
+        extra_valid_values=lenient_region_set
+    )
+    return Region.is_valid(val, options)

--- a/csv_detective/detect_fields/FR/other/code_rna/__init__.py
+++ b/csv_detective/detect_fields/FR/other/code_rna/__init__.py
@@ -1,5 +1,10 @@
-from frformat import CodeRNA
+from frformat import CodeRNA, Options
 
 PROPORTION = 0.9
 
-_is = CodeRNA.is_valid
+_code_rna = CodeRNA(Options())
+
+
+def _is(val):
+
+    return _code_rna.is_valid(val)

--- a/csv_detective/detect_fields/FR/other/code_rna/__init__.py
+++ b/csv_detective/detect_fields/FR/other/code_rna/__init__.py
@@ -1,8 +1,8 @@
-from frformat import CodeRNA, Options
+from frformat import CodeRNA
 
 PROPORTION = 0.9
 
-_code_rna = CodeRNA(Options())
+_code_rna = CodeRNA()
 
 
 def _is(val):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ odfpy==1.4.1
 requests==2.31.0
 responses==0.25.0
 python-magic==0.4.27
-frformat==0.3.0
+frformat==0.3.1


### PR DESCRIPTION
# Context

The aim of this PR is to adapt (by anticipation) to a breaking change of fr-format, coming in future version 0.4.0 ([PR #14](https://github.com/datagouv/fr-format/pull/14))


The changes introduced are: 

*  to replace the old parameter "strict"  with "options" to validate a given value. 
* The parameter "options" is a set of boolean variables that determine whether to ignore certain modifications on the given value or not.
* The format Validator must be instanciated instead of using static methods. 
